### PR TITLE
Add relative search path for native libs

### DIFF
--- a/src/main/java/org/abstractj/kalium/NaCl.java
+++ b/src/main/java/org/abstractj/kalium/NaCl.java
@@ -34,6 +34,7 @@ public class NaCl {
         public static final Sodium SODIUM_INSTANCE = LibraryLoader.create(Sodium.class)
                 .search("/usr/local/lib")
                 .search("/opt/local/lib")
+                .search("lib")
                 .load(LIBRARY_NAME);
     }
     


### PR DESCRIPTION
Hi,
wouldn't it be cool, to be able to deliver standalone applications? So it would be really nice, if the binaries for NaCl can stay in the subfolder "lib".
