### PR TITLE
Allow output length to be specified for hashing - useful for key derivation

### DIFF
--- a/src/main/java/org/abstractj/kalium/crypto/Password.java
+++ b/src/main/java/org/abstractj/kalium/crypto/Password.java
@@ -11,7 +11,11 @@ public class Password {
     }
 
     public String hash(byte[] passwd, Encoder encoder, byte[] salt, int opslimit, long memlimit) {
-        byte[] buffer = new byte[PWHASH_SCRYPTSALSA208SHA256_OUTBYTES];
+        return hash(PWHASH_SCRYPTSALSA208SHA256_OUTBYTES, passwd, encoder, salt, opslimit, memlimit);
+    }
+
+    public String hash(int length, byte[] passwd, Encoder encoder, byte[] salt, int opslimit, long memlimit) {
+        byte[] buffer = new byte[length];
         sodium().crypto_pwhash_scryptsalsa208sha256(buffer, buffer.length, passwd, passwd.length, salt, opslimit, memlimit);
         return encoder.encode(buffer);
     }

--- a/src/test/java/org/abstractj/kalium/crypto/PasswordTest.java
+++ b/src/test/java/org/abstractj/kalium/crypto/PasswordTest.java
@@ -4,6 +4,7 @@ import org.abstractj.kalium.NaCl;
 import org.junit.Test;
 
 import static junit.framework.Assert.assertTrue;
+import static org.abstractj.kalium.NaCl.Sodium.XSALSA20_POLY1305_SECRETBOX_KEYBYTES;
 import static org.abstractj.kalium.encoders.Encoder.HEX;
 import static org.abstractj.kalium.fixture.TestVectors.*;
 import static org.abstractj.kalium.fixture.TestVectors.PWHASH_MESSAGE;
@@ -66,5 +67,19 @@ public class PasswordTest {
         // Must return false since it's an invalid
         boolean verified2 = password.verify(hashed, ("i" + PWHASH_MESSAGE).getBytes());
         assertTrue("Valid password", !verified2);
+    }
+
+    @Test
+    public void testPWHashKeyDerivation() {
+        String result = password.hash(NaCl.Sodium.XSALSA20_POLY1305_SECRETBOX_KEYBYTES,
+                PWHASH_MESSAGE.getBytes(),
+                HEX,
+                PWHASH_SALT.getBytes(),
+                NaCl.Sodium.PWHASH_SCRYPTSALSA208SHA256_OPSLIMIT_INTERACTIVE,
+                NaCl.Sodium.PWHASH_SCRYPTSALSA208SHA256_MEMLIMIT_INTERACTIVE);
+        byte[] hashed = HEX.decode(result);
+
+        // Must receive expected size
+        assertEquals(NaCl.Sodium.XSALSA20_POLY1305_SECRETBOX_KEYBYTES, hashed.length);
     }
 }


### PR DESCRIPTION
The libsodium docs at https://download.libsodium.org/doc/password_hashing/index.html give an example of using crypto_pwhash_scryptsalsa208sha256 to derive a key of arbitrary length from a (potentially short) password, which can then be used to encrypt data. This commit simply exposes a length parameter on an existing hash method to make this possible for kalium users. A method without the length parameter has been left for backwards compatibility - it just delegates to the new method.