### PR TITLE
Box precomputes and uses the DH shared key.

### DIFF
--- a/src/main/java/org/abstractj/kalium/NaCl.java
+++ b/src/main/java/org/abstractj/kalium/NaCl.java
@@ -119,14 +119,24 @@ public class NaCl {
         public static final int NONCE_BYTES = 24;
         public static final int ZERO_BYTES = 32;
         public static final int BOXZERO_BYTES = 16;
+        public static final int BEFORENMBYTES = 32;
 
         public void randombytes(@Out byte[] buffer, @u_int64_t long size);
+
+        public int crypto_box_curve25519xsalsa20poly1305_beforenm(@Out byte[] sharedkey,
+                                                         @In byte[] publicKey, @In byte[] privateKey);
 
         public int crypto_box_curve25519xsalsa20poly1305(@Out byte[] ct, @In byte[] msg, @u_int64_t long length, @In byte[] nonce,
                                                          @In byte[] publicKey, @In byte[] privateKey);
 
+        public int crypto_box_curve25519xsalsa20poly1305_afternm(@Out byte[] ct, @In byte[] msg, @u_int64_t long length, @In byte[] nonce,
+                                                                 @In byte[] shared);
+
         public int crypto_box_curve25519xsalsa20poly1305_open(@Out byte[] message, @In byte[] ct, @u_int64_t long length,
                                                               @In byte[] nonce, @In byte[] publicKey, @In byte[] privateKey);
+
+        public int crypto_box_curve25519xsalsa20poly1305_open_afternm(@Out byte[] message, @In byte[] ct, @u_int64_t long length,
+                                                              @In byte[] nonce, @In byte[] shared);
 
         public static final int SCALAR_BYTES = 32;
 


### PR DESCRIPTION
Addes the three NaCl\Libsodium API calls for cryto_box.
 * crypto_box_curve25519xsalsa20poly1305_beforenm
 * crypto_box_curve25519xsalsa20poly1305_afternm
 * crypto_box_curve25519xsalsa20poly1305_open_afternm

You can get pretty big gains out of not having to calculate the shared key for each encryption and decryption operation.

I used this template to do some quick and dirty timing.

```java
    @Test
    public void testTime() throws Exception {
        int work = 10000;
        SecureRandom r = new SecureRandom();

        byte[][] messages = new byte[work][];
        byte[][] nonces = new byte[work][NaCl.Sodium.NONCE_BYTES];

        for (int i = 0; i < work; i++) {
            int msgLen = r.nextInt(4000) + 1000;
            byte[] msg = new byte[msgLen];
            r.nextBytes(msg);
            messages[i] = msg;

            byte[] nonce = new byte[NaCl.Sodium.NONCE_BYTES];
            r.nextBytes(nonce);
            nonces[i] = nonce;
        }

        long start = System.currentTimeMillis();

        Box box = new Box(new PublicKey(ALICE_PUBLIC_KEY), new PrivateKey(BOB_PRIVATE_KEY));
        Box box2 = new Box(new PublicKey(BOB_PUBLIC_KEY), new PrivateKey(ALICE_PRIVATE_KEY));

        for (int i = 0; i < work; i++) {
            byte[] ct = box.encrypt(nonces[i], messages[i]);
            box2.decrypt(nonces[i], ct);
        }

        long end = System.currentTimeMillis();
        long took = end - start;

        System.out.println("Took: " + took + "ms");
    }
```

**Without Precalculation (*before this change*)**
2421ms
2227ms
2227ms
2076ms
2020ms
2251ms
2094ms
2116ms
2209ms
2396ms

**With Precalculation (*after this change*)**
663ms
633ms
727ms
629ms
649ms
630ms
705ms
705ms
618ms
647ms

**With Precalculation and new instance for each operation (*moving the Box instantiation inside the for loop*)**
2096ms
2351ms
2351ms
2265ms
2359ms
2217ms
2255ms
2149ms
2441ms
2238ms
