### PR TITLE
Adds constant time (for length) operations.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,18 @@
 language: java
 
-before_script:
-  - wget -c https://github.com/jedisct1/libsodium/releases/download/1.0.3/libsodium-1.0.3.tar.gz
-  - tar xzvf libsodium-1.0.3.tar.gz
-  - cd libsodium-1.0.3 && mkdir vendor
+before_install:
+  - wget -c https://github.com/jedisct1/libsodium/releases/download/1.0.7/libsodium-1.0.7.tar.gz
+  - tar xzvf libsodium-1.0.7.tar.gz
+  - cd libsodium-1.0.7 && mkdir vendor
   - ./configure --prefix=`pwd`/vendor
   - make && make install
   - cd ../
 
 script:
-  - export LD_LIBRARY_PATH="/home/travis/build/abstractj/kalium/libsodium-1.0.3/vendor/lib"
+  - export LD_LIBRARY_PATH="/home/travis/build/abstractj/kalium/libsodium-1.0.7/vendor/lib"
   - mvn clean install
 
-env: JAVA_OPTS="-Djava.library.path=/home/travis/build/abstractj/kalium/libsodium-1.0.3/vendor/lib"
+env: JAVA_OPTS="-Djava.library.path=/home/travis/build/abstractj/kalium/libsodium-1.0.7/vendor/lib"
 
 jdk:
   - oraclejdk7
@@ -20,4 +20,4 @@ jdk:
   - oraclejdk8
 
 after_success:
-  - rm -rf libsodium-1.0.3*
+  - rm -rf libsodium-1.0.7*

--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,12 @@
             <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+            <version>0.1</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -169,6 +175,31 @@
                 <configuration>
                     <pushChanges>false</pushChanges>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>1.4.0</version>
+                <executions>
+                    <execution>
+                        <id>run-benchmarks</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <skip>${skipTests}</skip>
+                            <classpathScope>test</classpathScope>
+                            <executable>${java.home}/bin/java</executable>
+                            <arguments>
+                                <argument>-classpath</argument>
+                                <classpath/>
+                                <argument>org.openjdk.jmh.Main</argument>
+                                <argument>.*</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/org/abstractj/kalium/NaCl.java
+++ b/src/main/java/org/abstractj/kalium/NaCl.java
@@ -27,7 +27,7 @@ public class NaCl {
     public static Sodium sodium() {
         Sodium sodium = SingletonHolder.SODIUM_INSTANCE;
 
-        if(!(sodium.sodium_version_string().compareTo("1.0.3") >= 0)){
+        if(!(sodium.sodium_version_string().compareTo("1.0.10") >= 0)){
             String message = String.format("Unsupported libsodium version: %s. Please update",
                     sodium.sodium_version_string());
             throw new UnsupportedOperationException(message);
@@ -59,6 +59,8 @@ public class NaCl {
         public int sodium_init();
 
         public String sodium_version_string();
+
+        public int sodium_is_zero(@In byte[] n, @In @u_int64_t int nlen);
 
         public static final int HMACSHA512256_BYTES = 32;
 

--- a/src/main/java/org/abstractj/kalium/crypto/Util.java
+++ b/src/main/java/org/abstractj/kalium/crypto/Util.java
@@ -57,4 +57,40 @@ public class Util {
         System.arraycopy(message, 0, result, signature.length, message.length);
         return result;
     }
+
+    public static boolean constantTimeEquals(byte[] b1, byte[] b2) {
+        if (b1.length != b2.length) {
+            return false;
+        }
+        int d = 0;
+        for (int i = 0; i < b1.length; i++) {
+            d |= (b1[i] ^ b2[i]);
+        }
+        return d == 0;
+    }
+
+    public static int constantTimeCompare(byte[] b1, byte[] b2) {
+        if (b1.length < b2.length) {
+            return -1;
+        } else if (b1.length < b2.length) {
+            return 1;
+        }
+        int gt = 0;
+        int eq = 1;
+        int i = b1.length;
+        while (i != 0) {
+            i--;
+            gt |= ((b2[i] - b1[i]) >> 8) & eq;
+            eq &= ((b2[i] ^ b1[i]) - 1) >> 8;
+        }
+        return (gt + gt + eq) - 1;
+    }
+
+    public static boolean constantTimeIsZero(byte[] n) {
+        int d = 0;
+        for (int i = 0; i < n.length; i++) {
+            d |= n[i];
+        }
+        return d == 0;
+    }
 }

--- a/src/test/java/org/abstractj/kalium/crypto/UtilConstantTimeBench.java
+++ b/src/test/java/org/abstractj/kalium/crypto/UtilConstantTimeBench.java
@@ -1,0 +1,41 @@
+package org.abstractj.kalium.crypto;
+
+import org.abstractj.kalium.NaCl;
+import org.openjdk.jmh.Main;
+import org.openjdk.jmh.annotations.GenerateMicroBenchmark;
+import org.openjdk.jmh.annotations.State;
+
+@State
+public class UtilConstantTimeBench {
+
+    byte[] a = new byte[32];
+    byte[] z = new byte[32];
+
+    public UtilConstantTimeBench() {
+        NaCl.sodium().randombytes(a, 32);
+    }
+
+    @GenerateMicroBenchmark
+    public void testNativeNotZero() throws Exception {
+        Util.constantTimeIsZero(a);
+    }
+
+    @GenerateMicroBenchmark
+    public void testNativeZero() throws Exception {
+        Util.constantTimeIsZero(z);
+    }
+
+    @GenerateMicroBenchmark
+    public void testFfiNotZero() throws Exception {
+        NaCl.sodium().sodium_is_zero(a, 32);
+    }
+
+    @GenerateMicroBenchmark
+    public void testFfiZero() throws Exception {
+        NaCl.sodium().sodium_is_zero(z, 32);
+    }
+
+    public static void main(String[] args) {
+        Main.main(args);
+    }
+}


### PR DESCRIPTION
This adds equals, compare, and isZero operations to Util.java that are comparable to sodium/util.h versions.

Running these functions in Java is much faster than going though to the overhead to the native libsodium implementations.
- `memcmp` -> https://github.com/jedisct1/libsodium/blob/1.0.8/src/libsodium/sodium/utils.c#L98-L117
- `compare` -> https://github.com/jedisct1/libsodium/blob/1.0.8/src/libsodium/sodium/utils.c#L132-L155
- `is_zero` -> https://github.com/jedisct1/libsodium/blob/1.0.8/src/libsodium/sodium/utils.c#L158-L167 
