### PR TITLE
Add deriveKey method for Password

### DIFF
--- a/src/main/java/org/abstractj/kalium/crypto/Password.java
+++ b/src/main/java/org/abstractj/kalium/crypto/Password.java
@@ -10,13 +10,19 @@ public class Password {
     public Password() {
     }
 
+    public byte[] deriveKey(int length, byte[] passwd, byte[] salt, int opslimit, long memlimit) {
+        byte[] buffer = new byte[length];
+        sodium().crypto_pwhash_scryptsalsa208sha256(buffer, buffer.length, passwd, passwd.length, salt, opslimit, memlimit);
+        return buffer;
+    }
+
     public String hash(byte[] passwd, Encoder encoder, byte[] salt, int opslimit, long memlimit) {
-        return hash(PWHASH_SCRYPTSALSA208SHA256_OUTBYTES, passwd, encoder, salt, opslimit, memlimit);
+        byte[] buffer = deriveKey(PWHASH_SCRYPTSALSA208SHA256_OUTBYTES, passwd, salt, opslimit, memlimit);
+        return encoder.encode(buffer);
     }
 
     public String hash(int length, byte[] passwd, Encoder encoder, byte[] salt, int opslimit, long memlimit) {
-        byte[] buffer = new byte[length];
-        sodium().crypto_pwhash_scryptsalsa208sha256(buffer, buffer.length, passwd, passwd.length, salt, opslimit, memlimit);
+        byte[] buffer = deriveKey(length, passwd, salt, opslimit, memlimit);
         return encoder.encode(buffer);
     }
 

--- a/src/test/java/org/abstractj/kalium/crypto/PasswordTest.java
+++ b/src/test/java/org/abstractj/kalium/crypto/PasswordTest.java
@@ -82,4 +82,16 @@ public class PasswordTest {
         // Must receive expected size
         assertEquals(NaCl.Sodium.XSALSA20_POLY1305_SECRETBOX_KEYBYTES, hashed.length);
     }
+
+    @Test
+    public void testPWHashKeyDerivationBytes() {
+        byte[] key = password.deriveKey(NaCl.Sodium.XSALSA20_POLY1305_SECRETBOX_KEYBYTES,
+                PWHASH_MESSAGE.getBytes(),
+                PWHASH_SALT.getBytes(),
+                NaCl.Sodium.PWHASH_SCRYPTSALSA208SHA256_OPSLIMIT_INTERACTIVE,
+                NaCl.Sodium.PWHASH_SCRYPTSALSA208SHA256_MEMLIMIT_INTERACTIVE);
+
+        // Must receive expected size
+        assertEquals(NaCl.Sodium.XSALSA20_POLY1305_SECRETBOX_KEYBYTES, key.length);
+    }
 }


### PR DESCRIPTION
I added versions of Password.hash that return a byte array rather than a string. As I understand it, this is important when using pwhash to derive a key as opposed to password storage, because you will want to clear the key from memory as soon as possible after deriving and using it. If the derived key is converted to an immutable string, this is not possible.

I converted the existing methods to call into the new one where appropriate, but left them otherwise unchanged to avoid making breaking changes; hopefully the name difference will prompt users to choose the byte array methods for key derivation and the string methods for password storage.