### PR TITLE
Standardized to Libsodium constraint names

### DIFF
--- a/src/main/java/org/abstractj/kalium/NaCl.java
+++ b/src/main/java/org/abstractj/kalium/NaCl.java
@@ -85,8 +85,9 @@ public class NaCl {
         // ---------------------------------------------------------------------
         // Secret-key cryptography: Authenticated encryption
 
-        int XSALSA20_POLY1305_SECRETBOX_KEYBYTES = 32;
-        int XSALSA20_POLY1305_SECRETBOX_NONCEBYTES = 24;
+        int CRYPTO_SECRETBOX_XSALSA20POLY1305_KEYBYTES = 32;
+
+        int CRYPTO_SECRETBOX_XSALSA20POLY1305_NONCEBYTES = 24;
 
         int crypto_secretbox_xsalsa20poly1305(
                 @Out byte[] ct, @In byte[] msg, @In @u_int64_t int length,
@@ -99,9 +100,9 @@ public class NaCl {
         // ---------------------------------------------------------------------
         // Secret-key cryptography: Authentication
 
-        int HMACSHA512256_BYTES = 32;
+        int CRYPTO_AUTH_HMACSHA512256_BYTES = 32;
 
-        int HMACSHA512256_KEYBYTES = 32;
+        int CRYPTO_AUTH_HMACSHA512256_KEYBYTES = 32;
 
         int crypto_auth_hmacsha512256(
                 @Out byte[] mac, @In byte[] message, @In @u_int64_t int sizeof,
@@ -119,18 +120,24 @@ public class NaCl {
         // ---------------------------------------------------------------------
         // Public-key cryptography: Authenticated encryption
 
-        int PUBLICKEY_BYTES = 32;
-        int SECRETKEY_BYTES = 32;
+        int CRYPTO_BOX_CURVE25519XSALSA20POLY1305_PUBLICKEYBYTES = 32;
+
+        int CRYPTO_BOX_CURVE25519XSALSA20POLY1305_SECRETKEYBYTES = 32;
+
+        int CRYPTO_BOX_CURVE25519XSALSA20POLY1305_ZEROBYTES = 32;
+
+        int CRYPTO_BOX_CURVE25519XSALSA20POLY1305_BOXZEROBYTES = 16;
+
+        int CRYPTO_BOX_CURVE25519XSALSA20POLY1305_MACBYTES =
+                CRYPTO_BOX_CURVE25519XSALSA20POLY1305_ZEROBYTES -
+                        CRYPTO_BOX_CURVE25519XSALSA20POLY1305_BOXZEROBYTES;
+
+        int CRYPTO_BOX_CURVE25519XSALSA20POLY1305_NONCEBYTES = 24;
+
+        int CRYPTO_BOX_CURVE25519XSALSA20POLY1305_BEFORENMBYTES = 32;
 
         int crypto_box_curve25519xsalsa20poly1305_keypair(
                 @Out byte[] publicKey, @Out byte[] secretKey);
-
-        int NONCE_BYTES = 24;
-        int ZERO_BYTES = 32;
-        int BOXZERO_BYTES = 16;
-        int BEFORENMBYTES = 32;
-        int MAC_BYTES = ZERO_BYTES - BOXZERO_BYTES;
-        int SEAL_BYTES = PUBLICKEY_BYTES + MAC_BYTES;
 
         int crypto_box_curve25519xsalsa20poly1305_beforenm(
                 @Out byte[] sharedkey, @In byte[] publicKey,
@@ -155,7 +162,11 @@ public class NaCl {
         // ---------------------------------------------------------------------
         // Public-key cryptography: Public-key signatures
 
-        int SIGNATURE_BYTES = 64;
+        int CRYPTO_SIGN_ED25519_PUBLICKEYBYTES = 32;
+
+        int CRYPTO_SIGN_ED25519_SECRETKEYBYTES = 64;
+
+        int CRYPTO_SIGN_ED25519_BYTES = 64;
 
         int crypto_sign_ed25519_seed_keypair(
                 @Out byte[] publicKey, @Out byte[] secretKey, @In byte[] seed);
@@ -173,6 +184,10 @@ public class NaCl {
         // ---------------------------------------------------------------------
         // Public-key cryptography: Sealed boxes
 
+        int CRYPTO_BOX_SEALBYTES =
+                CRYPTO_BOX_CURVE25519XSALSA20POLY1305_PUBLICKEYBYTES +
+                        CRYPTO_BOX_CURVE25519XSALSA20POLY1305_MACBYTES;
+
         int crypto_box_seal(
                 @Out byte[] ct, @In byte[] message, @In @u_int64_t int length,
                 @In byte[] publicKey);
@@ -184,7 +199,17 @@ public class NaCl {
         // ---------------------------------------------------------------------
         // Hashing: Generic hashing
 
-        int BLAKE2B_OUTBYTES = 32;
+        int CRYPTO_GENERICHASH_BLAKE2B_BYTES = 32;
+
+        int CRYPTO_GENERICHASH_BLAKE2B_BYTES_MIN = 16;
+
+        int CRYPTO_GENERICHASH_BLAKE2B_BYTES_MAX = 64;
+
+        int CRYPTO_GENERICHASH_BLAKE2B_KEYBYTES = 32;
+
+        int CRYPTO_GENERICHASH_BLAKE2B_KEYBYTES_MIN = 16;
+
+        int CRYPTO_GENERICHASH_BLAKE2B_KEYBYTES_MAX = 64;
 
         int crypto_generichash_blake2b(
                 @Out byte[] buffer, @In @u_int64_t int outLen,
@@ -205,10 +230,13 @@ public class NaCl {
         // ---------------------------------------------------------------------
         // Password hashing
 
-        int PWHASH_SCRYPTSALSA208SHA256_STRBYTES = 102;
-        int PWHASH_SCRYPTSALSA208SHA256_OUTBYTES = 64;
-        int PWHASH_SCRYPTSALSA208SHA256_OPSLIMIT_INTERACTIVE = 524288;
-        int PWHASH_SCRYPTSALSA208SHA256_MEMLIMIT_INTERACTIVE = 16777216;
+        int CRYPTO_PWHASH_SCRYPTSALSA208SHA256_STRBYTES = 102;
+
+        int CRYPTO_PWHASH_SCRYPTSALSA208SHA256_OUTBYTES = 64;
+
+        int CRYPTO_PWHASH_SCRYPTSALSA208SHA256_OPSLIMIT_INTERACTIVE = 524288;
+
+        int CRYPTO_PWHASH_SCRYPTSALSA208SHA256_MEMLIMIT_INTERACTIVE = 16777216;
 
         int crypto_pwhash_scryptsalsa208sha256(
                 @Out byte[] buffer, @In @u_int64_t int outlen,
@@ -233,13 +261,13 @@ public class NaCl {
         // ---------------------------------------------------------------------
         // Advanced: SHA-2
 
-        int SHA256BYTES = 32;
+        int CRYPTO_HASH_SHA256_BYTES = 32;
 
         int crypto_hash_sha256(
                 @Out byte[] buffer, @In byte[] message,
                 @In @u_int64_t int sizeof);
 
-        int SHA512BYTES = 64;
+        int CRYPTO_HASH_SHA512_BYTES = 64;
 
         int crypto_hash_sha512(
                 @Out byte[] buffer, @In byte[] message,
@@ -258,7 +286,9 @@ public class NaCl {
         // ---------------------------------------------------------------------
         // Advanced: Diffie-Hellman
 
-        int SCALAR_BYTES = 32;
+        int CRYPTO_SCALARMULT_CURVE25519_SCALARBYTES = 32;
+
+        int CRYPTO_SCALARMULT_CURVE25519_BYTES = 32;
 
         int crypto_scalarmult_curve25519(
                 @Out byte[] result, @In byte[] intValue, @In byte[] point);

--- a/src/main/java/org/abstractj/kalium/NaCl.java
+++ b/src/main/java/org/abstractj/kalium/NaCl.java
@@ -85,6 +85,18 @@ public class NaCl {
         // ---------------------------------------------------------------------
         // Secret-key cryptography: Authenticated encryption
 
+        /**
+         * @deprecated use CRYPTO_SECRETBOX_XSALSA20POLY1305_KEYBYTES
+         */
+        @Deprecated
+        int XSALSA20_POLY1305_SECRETBOX_KEYBYTES = 32;
+
+        /**
+         * @deprecated use CRYPTO_SECRETBOX_XSALSA20POLY1305_NONCEBYTES
+         */
+        @Deprecated
+        int XSALSA20_POLY1305_SECRETBOX_NONCEBYTES = 24;
+
         int CRYPTO_SECRETBOX_XSALSA20POLY1305_KEYBYTES = 32;
 
         int CRYPTO_SECRETBOX_XSALSA20POLY1305_NONCEBYTES = 24;
@@ -99,6 +111,18 @@ public class NaCl {
 
         // ---------------------------------------------------------------------
         // Secret-key cryptography: Authentication
+
+        /**
+         * @deprecated use CRYPTO_AUTH_HMACSHA512256_BYTESS
+         */
+        @Deprecated
+        int HMACSHA512256_BYTES = 32;
+
+        /**
+         * @deprecated use CRYPTO_AUTH_HMACSHA512256_KEYBYTESS
+         */
+        @Deprecated
+        int HMACSHA512256_KEYBYTES = 32;
 
         int CRYPTO_AUTH_HMACSHA512256_BYTES = 32;
 
@@ -119,6 +143,36 @@ public class NaCl {
 
         // ---------------------------------------------------------------------
         // Public-key cryptography: Authenticated encryption
+
+        /**
+         * @deprecated use CRYPTO_BOX_CURVE25519XSALSA20POLY1305_PUBLICKEYBYTESS
+         */
+        @Deprecated
+        int PUBLICKEY_BYTES = 32;
+
+        /**
+         * @deprecated use CRYPTO_BOX_CURVE25519XSALSA20POLY1305_SECRETKEYBYTESS
+         */
+        @Deprecated
+        int SECRETKEY_BYTES = 32;
+
+        /**
+         * @deprecated use CRYPTO_BOX_CURVE25519XSALSA20POLY1305_NONCEBYTES
+         */
+        @Deprecated
+        int NONCE_BYTES = 24;
+
+        /**
+         * @deprecated use CRYPTO_BOX_CURVE25519XSALSA20POLY1305_ZEROBYTESS
+         */
+        @Deprecated
+        int ZERO_BYTES = 32;
+
+        /**
+         * @deprecated use CRYPTO_BOX_CURVE25519XSALSA20POLY1305_BOXZEROBYTES
+         */
+        @Deprecated
+        int BOXZERO_BYTES = 16;
 
         int CRYPTO_BOX_CURVE25519XSALSA20POLY1305_PUBLICKEYBYTES = 32;
 
@@ -162,6 +216,12 @@ public class NaCl {
         // ---------------------------------------------------------------------
         // Public-key cryptography: Public-key signatures
 
+        /**
+         * @deprecated use the documented CRYPTO_SIGN_ED25519_BYTES.
+         */
+        @Deprecated
+        int SIGNATURE_BYTES = 64;
+
         int CRYPTO_SIGN_ED25519_PUBLICKEYBYTES = 32;
 
         int CRYPTO_SIGN_ED25519_SECRETKEYBYTES = 64;
@@ -199,6 +259,13 @@ public class NaCl {
         // ---------------------------------------------------------------------
         // Hashing: Generic hashing
 
+        /**
+         * @deprecated use CRYPTO_GENERICHASH_BLAKE2B_BYTES_MAX. Note that
+         * the Libsodium standard value is '32' and not '64' as defined here.
+         */
+        @Deprecated
+        int BLAKE2B_OUTBYTES = 64;
+
         int CRYPTO_GENERICHASH_BLAKE2B_BYTES = 32;
 
         int CRYPTO_GENERICHASH_BLAKE2B_BYTES_MIN = 16;
@@ -230,6 +297,31 @@ public class NaCl {
         // ---------------------------------------------------------------------
         // Password hashing
 
+        /**
+         * @deprecated use CRYPTO_PWHASH_SCRYPTSALSA208SHA256_STRBYTES
+         */
+        @Deprecated
+        int PWHASH_SCRYPTSALSA208SHA256_STRBYTES = 102;
+
+        /**
+         * @deprecated use CRYPTO_PWHASH_SCRYPTSALSA208SHA256_OUTBYTES
+         */
+        @Deprecated
+        int PWHASH_SCRYPTSALSA208SHA256_OUTBYTES = 64;
+
+        /**
+         * @deprecated use CRYPTO_PWHASH_SCRYPTSALSA208SHA256_OPSLIMIT_INTERACTIVE
+         */
+        @Deprecated
+        int PWHASH_SCRYPTSALSA208SHA256_OPSLIMIT_INTERACTIVE = 524288;
+
+        /**
+         * @deprecated use CRYPTO_PWHASH_SCRYPTSALSA208SHA256_MEMLIMIT_INTERACTIVE
+         */
+        @Deprecated
+        int PWHASH_SCRYPTSALSA208SHA256_MEMLIMIT_INTERACTIVE = 16777216;
+
+
         int CRYPTO_PWHASH_SCRYPTSALSA208SHA256_STRBYTES = 102;
 
         int CRYPTO_PWHASH_SCRYPTSALSA208SHA256_OUTBYTES = 64;
@@ -260,6 +352,16 @@ public class NaCl {
 
         // ---------------------------------------------------------------------
         // Advanced: SHA-2
+
+        /**
+         * @deprecated use CRYPTO_HASH_SHA256_BYTES
+         */
+        int SHA256BYTES = 32;
+
+        /**
+         * @deprecated use CRYPTO_HASH_SHA512_BYTES
+         */
+        int SHA512BYTES = 64;
 
         int CRYPTO_HASH_SHA256_BYTES = 32;
 

--- a/src/main/java/org/abstractj/kalium/crypto/Box.java
+++ b/src/main/java/org/abstractj/kalium/crypto/Box.java
@@ -21,11 +21,11 @@ import org.abstractj.kalium.encoders.Encoder;
 import org.abstractj.kalium.keys.PrivateKey;
 import org.abstractj.kalium.keys.PublicKey;
 
-import static org.abstractj.kalium.NaCl.Sodium.BOXZERO_BYTES;
-import static org.abstractj.kalium.NaCl.Sodium.NONCE_BYTES;
-import static org.abstractj.kalium.NaCl.Sodium.PUBLICKEY_BYTES;
-import static org.abstractj.kalium.NaCl.Sodium.SECRETKEY_BYTES;
-import static org.abstractj.kalium.NaCl.Sodium.ZERO_BYTES;
+import static org.abstractj.kalium.NaCl.Sodium.CRYPTO_BOX_CURVE25519XSALSA20POLY1305_BOXZEROBYTES;
+import static org.abstractj.kalium.NaCl.Sodium.CRYPTO_BOX_CURVE25519XSALSA20POLY1305_NONCEBYTES;
+import static org.abstractj.kalium.NaCl.Sodium.CRYPTO_BOX_CURVE25519XSALSA20POLY1305_PUBLICKEYBYTES;
+import static org.abstractj.kalium.NaCl.Sodium.CRYPTO_BOX_CURVE25519XSALSA20POLY1305_SECRETKEYBYTES;
+import static org.abstractj.kalium.NaCl.Sodium.CRYPTO_BOX_CURVE25519XSALSA20POLY1305_ZEROBYTES;
 import static org.abstractj.kalium.NaCl.sodium;
 import static org.abstractj.kalium.crypto.Util.checkLength;
 import static org.abstractj.kalium.crypto.Util.isValid;
@@ -40,10 +40,10 @@ public class Box {
     private final byte[] sharedKey;
 
     public Box(byte[] publicKey, byte[] privateKey) {
-        checkLength(publicKey, PUBLICKEY_BYTES);
-        checkLength(privateKey, SECRETKEY_BYTES);
+        checkLength(publicKey, CRYPTO_BOX_CURVE25519XSALSA20POLY1305_PUBLICKEYBYTES);
+        checkLength(privateKey, CRYPTO_BOX_CURVE25519XSALSA20POLY1305_SECRETKEYBYTES);
 
-        sharedKey = new byte[NaCl.Sodium.BEFORENMBYTES];
+        sharedKey = new byte[NaCl.Sodium.CRYPTO_BOX_CURVE25519XSALSA20POLY1305_BEFORENMBYTES];
         isValid(sodium().crypto_box_curve25519xsalsa20poly1305_beforenm(
                 sharedKey, publicKey, privateKey), "Key agreement failed");
     }
@@ -57,12 +57,12 @@ public class Box {
     }
 
     public byte[] encrypt(byte[] nonce, byte[] message) {
-        checkLength(nonce, NONCE_BYTES);
-        byte[] msg = prependZeros(ZERO_BYTES, message);
+        checkLength(nonce, CRYPTO_BOX_CURVE25519XSALSA20POLY1305_NONCEBYTES);
+        byte[] msg = prependZeros(CRYPTO_BOX_CURVE25519XSALSA20POLY1305_ZEROBYTES, message);
         byte[] ct = new byte[msg.length];
         isValid(sodium().crypto_box_curve25519xsalsa20poly1305_afternm(ct, msg,
                 msg.length, nonce, sharedKey), "Encryption failed");
-        return removeZeros(BOXZERO_BYTES, ct);
+        return removeZeros(CRYPTO_BOX_CURVE25519XSALSA20POLY1305_BOXZEROBYTES, ct);
     }
 
     public byte[] encrypt(String nonce, String message, Encoder encoder) {
@@ -70,13 +70,13 @@ public class Box {
     }
 
     public byte[] decrypt(byte[] nonce, byte[] ciphertext) {
-        checkLength(nonce, NONCE_BYTES);
-        byte[] ct = prependZeros(BOXZERO_BYTES, ciphertext);
+        checkLength(nonce, CRYPTO_BOX_CURVE25519XSALSA20POLY1305_NONCEBYTES);
+        byte[] ct = prependZeros(CRYPTO_BOX_CURVE25519XSALSA20POLY1305_BOXZEROBYTES, ciphertext);
         byte[] message = new byte[ct.length];
         isValid(sodium().crypto_box_curve25519xsalsa20poly1305_open_afternm(
                         message, ct, message.length, nonce, sharedKey),
                 "Decryption failed. Ciphertext failed verification.");
-        return removeZeros(ZERO_BYTES, message);
+        return removeZeros(CRYPTO_BOX_CURVE25519XSALSA20POLY1305_ZEROBYTES, message);
     }
 
     public byte[] decrypt(String nonce, String ciphertext, Encoder encoder) {

--- a/src/main/java/org/abstractj/kalium/crypto/Hash.java
+++ b/src/main/java/org/abstractj/kalium/crypto/Hash.java
@@ -18,21 +18,21 @@ package org.abstractj.kalium.crypto;
 
 import org.abstractj.kalium.encoders.Encoder;
 
-import static org.abstractj.kalium.NaCl.Sodium.BLAKE2B_OUTBYTES;
-import static org.abstractj.kalium.NaCl.Sodium.SHA256BYTES;
-import static org.abstractj.kalium.NaCl.Sodium.SHA512BYTES;
+import static org.abstractj.kalium.NaCl.Sodium.CRYPTO_GENERICHASH_BLAKE2B_BYTES;
+import static org.abstractj.kalium.NaCl.Sodium.CRYPTO_HASH_SHA256_BYTES;
+import static org.abstractj.kalium.NaCl.Sodium.CRYPTO_HASH_SHA512_BYTES;
 import static org.abstractj.kalium.NaCl.sodium;
 
 public class Hash {
 
     public byte[] sha256(byte[] message) {
-        byte[] buffer = new byte[SHA256BYTES];
+        byte[] buffer = new byte[CRYPTO_HASH_SHA256_BYTES];
         sodium().crypto_hash_sha256(buffer, message, message.length);
         return buffer;
     }
 
     public byte[] sha512(byte[] message) {
-        byte[] buffer = new byte[SHA512BYTES];
+        byte[] buffer = new byte[CRYPTO_HASH_SHA512_BYTES];
         sodium().crypto_hash_sha512(buffer, message, message.length);
         return buffer;
     }
@@ -49,8 +49,8 @@ public class Hash {
 
 
     public byte[] blake2(byte[] message) throws UnsupportedOperationException {
-        byte[] buffer = new byte[BLAKE2B_OUTBYTES];
-        sodium().crypto_generichash_blake2b(buffer, BLAKE2B_OUTBYTES, message, message.length, null, 0);
+        byte[] buffer = new byte[CRYPTO_GENERICHASH_BLAKE2B_BYTES];
+        sodium().crypto_generichash_blake2b(buffer, CRYPTO_GENERICHASH_BLAKE2B_BYTES, message, message.length, null, 0);
         return buffer;
     }
 
@@ -60,8 +60,8 @@ public class Hash {
     }
 
     public byte[] blake2(byte[] message, byte[] key, byte[] salt, byte[] personal) throws UnsupportedOperationException {
-        byte[] buffer = new byte[BLAKE2B_OUTBYTES];
-        sodium().crypto_generichash_blake2b_salt_personal(buffer, BLAKE2B_OUTBYTES,
+        byte[] buffer = new byte[CRYPTO_GENERICHASH_BLAKE2B_BYTES];
+        sodium().crypto_generichash_blake2b_salt_personal(buffer, CRYPTO_GENERICHASH_BLAKE2B_BYTES,
                                                           message, message.length,
                                                           key, key.length,
                                                           salt, personal);

--- a/src/main/java/org/abstractj/kalium/crypto/Password.java
+++ b/src/main/java/org/abstractj/kalium/crypto/Password.java
@@ -1,7 +1,7 @@
 package org.abstractj.kalium.crypto;
 
-import static org.abstractj.kalium.NaCl.Sodium.PWHASH_SCRYPTSALSA208SHA256_OUTBYTES;
-import static org.abstractj.kalium.NaCl.Sodium.PWHASH_SCRYPTSALSA208SHA256_STRBYTES;
+import static org.abstractj.kalium.NaCl.Sodium.CRYPTO_PWHASH_SCRYPTSALSA208SHA256_OUTBYTES;
+import static org.abstractj.kalium.NaCl.Sodium.CRYPTO_PWHASH_SCRYPTSALSA208SHA256_STRBYTES;
 import static org.abstractj.kalium.NaCl.sodium;
 import org.abstractj.kalium.encoders.Encoder;
 
@@ -9,7 +9,6 @@ public class Password {
 
     public Password() {
     }
-
     public byte[] deriveKey(int length, byte[] passwd, byte[] salt, int opslimit, long memlimit) {
         byte[] buffer = new byte[length];
         sodium().crypto_pwhash_scryptsalsa208sha256(buffer, buffer.length, passwd, passwd.length, salt, opslimit, memlimit);
@@ -17,7 +16,7 @@ public class Password {
     }
 
     public String hash(byte[] passwd, Encoder encoder, byte[] salt, int opslimit, long memlimit) {
-        byte[] buffer = deriveKey(PWHASH_SCRYPTSALSA208SHA256_OUTBYTES, passwd, salt, opslimit, memlimit);
+        byte[] buffer = deriveKey(CRYPTO_PWHASH_SCRYPTSALSA208SHA256_OUTBYTES, passwd, salt, opslimit, memlimit);
         return encoder.encode(buffer);
     }
 
@@ -27,7 +26,7 @@ public class Password {
     }
 
     public String hash(byte[] passwd, Encoder encoder, int opslimit, long memlimit) {
-        byte[] buffer = new byte[PWHASH_SCRYPTSALSA208SHA256_STRBYTES];
+        byte[] buffer = new byte[CRYPTO_PWHASH_SCRYPTSALSA208SHA256_STRBYTES];
         sodium().crypto_pwhash_scryptsalsa208sha256_str(buffer, passwd, passwd.length, opslimit, memlimit);
         return encoder.encode(buffer);
     }

--- a/src/main/java/org/abstractj/kalium/crypto/Point.java
+++ b/src/main/java/org/abstractj/kalium/crypto/Point.java
@@ -18,7 +18,7 @@ package org.abstractj.kalium.crypto;
 
 import org.abstractj.kalium.encoders.Encoder;
 
-import static org.abstractj.kalium.NaCl.Sodium.SCALAR_BYTES;
+import static org.abstractj.kalium.NaCl.Sodium.CRYPTO_SCALARMULT_CURVE25519_SCALARBYTES;
 import static org.abstractj.kalium.NaCl.sodium;
 import static org.abstractj.kalium.crypto.Util.zeros;
 import static org.abstractj.kalium.encoders.Encoder.HEX;
@@ -42,7 +42,7 @@ public class Point {
     }
 
     public Point mult(byte[] n) {
-        byte[] result = zeros(SCALAR_BYTES);
+        byte[] result = zeros(CRYPTO_SCALARMULT_CURVE25519_SCALARBYTES);
         sodium().crypto_scalarmult_curve25519(result, n, point);
         return new Point(result);
     }

--- a/src/main/java/org/abstractj/kalium/crypto/SealedBox.java
+++ b/src/main/java/org/abstractj/kalium/crypto/SealedBox.java
@@ -2,7 +2,7 @@ package org.abstractj.kalium.crypto;
 
 import org.abstractj.kalium.encoders.Encoder;
 
-import static org.abstractj.kalium.NaCl.Sodium.SEAL_BYTES;
+import static org.abstractj.kalium.NaCl.Sodium.CRYPTO_BOX_SEALBYTES;
 import static org.abstractj.kalium.NaCl.sodium;
 import static org.abstractj.kalium.crypto.Util.isValid;
 
@@ -30,7 +30,7 @@ public class SealedBox {
     }
 
     public byte[] encrypt(byte[] message) {
-        byte[] ct = new byte[message.length + SEAL_BYTES];
+        byte[] ct = new byte[message.length + CRYPTO_BOX_SEALBYTES];
         isValid(sodium().crypto_box_seal(
                         ct, message, message.length, publicKey),
                 "Encryption failed");
@@ -41,7 +41,7 @@ public class SealedBox {
         if (privateKey == null)
             throw new RuntimeException("Decryption failed. Private key not available.");
 
-        byte[] message = new byte[ciphertext.length - SEAL_BYTES];
+        byte[] message = new byte[ciphertext.length - CRYPTO_BOX_SEALBYTES];
         isValid(sodium().crypto_box_seal_open(
                         message, ciphertext, ciphertext.length, publicKey, privateKey),
                 "Decryption failed. Ciphertext failed verification");

--- a/src/main/java/org/abstractj/kalium/crypto/SecretBox.java
+++ b/src/main/java/org/abstractj/kalium/crypto/SecretBox.java
@@ -18,10 +18,10 @@ package org.abstractj.kalium.crypto;
 
 import org.abstractj.kalium.encoders.Encoder;
 
-import static org.abstractj.kalium.NaCl.Sodium.BOXZERO_BYTES;
-import static org.abstractj.kalium.NaCl.Sodium.XSALSA20_POLY1305_SECRETBOX_NONCEBYTES;
-import static org.abstractj.kalium.NaCl.Sodium.XSALSA20_POLY1305_SECRETBOX_KEYBYTES;
-import static org.abstractj.kalium.NaCl.Sodium.ZERO_BYTES;
+import static org.abstractj.kalium.NaCl.Sodium.CRYPTO_BOX_CURVE25519XSALSA20POLY1305_BOXZEROBYTES;
+import static org.abstractj.kalium.NaCl.Sodium.CRYPTO_SECRETBOX_XSALSA20POLY1305_NONCEBYTES;
+import static org.abstractj.kalium.NaCl.Sodium.CRYPTO_SECRETBOX_XSALSA20POLY1305_KEYBYTES;
+import static org.abstractj.kalium.NaCl.Sodium.CRYPTO_BOX_CURVE25519XSALSA20POLY1305_ZEROBYTES;
 import static org.abstractj.kalium.NaCl.sodium;
 import static org.abstractj.kalium.crypto.Util.checkLength;
 import static org.abstractj.kalium.crypto.Util.isValid;
@@ -33,7 +33,7 @@ public class SecretBox {
 
     public SecretBox(byte[] key) {
         this.key = key;
-        checkLength(key, XSALSA20_POLY1305_SECRETBOX_KEYBYTES);
+        checkLength(key, CRYPTO_SECRETBOX_XSALSA20POLY1305_KEYBYTES);
     }
 
     public SecretBox(String key, Encoder encoder) {
@@ -41,20 +41,20 @@ public class SecretBox {
     }
 
     public byte[] encrypt(byte[] nonce, byte[] message) {
-        checkLength(nonce, XSALSA20_POLY1305_SECRETBOX_NONCEBYTES);
-        byte[] msg = Util.prependZeros(ZERO_BYTES, message);
+        checkLength(nonce, CRYPTO_SECRETBOX_XSALSA20POLY1305_NONCEBYTES);
+        byte[] msg = Util.prependZeros(CRYPTO_BOX_CURVE25519XSALSA20POLY1305_ZEROBYTES, message);
         byte[] ct = Util.zeros(msg.length);
         isValid(sodium().crypto_secretbox_xsalsa20poly1305(ct, msg, msg.length,
                 nonce, key), "Encryption failed");
-        return removeZeros(BOXZERO_BYTES, ct);
+        return removeZeros(CRYPTO_BOX_CURVE25519XSALSA20POLY1305_BOXZEROBYTES, ct);
     }
 
     public byte[] decrypt(byte[] nonce, byte[] ciphertext) {
-        checkLength(nonce, XSALSA20_POLY1305_SECRETBOX_NONCEBYTES);
-        byte[] ct = Util.prependZeros(BOXZERO_BYTES, ciphertext);
+        checkLength(nonce, CRYPTO_SECRETBOX_XSALSA20POLY1305_NONCEBYTES);
+        byte[] ct = Util.prependZeros(CRYPTO_BOX_CURVE25519XSALSA20POLY1305_BOXZEROBYTES, ciphertext);
         byte[] message = Util.zeros(ct.length);
         isValid(sodium().crypto_secretbox_xsalsa20poly1305_open(message, ct,
                 ct.length, nonce, key), "Decryption failed. Ciphertext failed verification");
-        return removeZeros(ZERO_BYTES, message);
+        return removeZeros(CRYPTO_BOX_CURVE25519XSALSA20POLY1305_ZEROBYTES, message);
     }
 }

--- a/src/main/java/org/abstractj/kalium/keys/AuthenticationKey.java
+++ b/src/main/java/org/abstractj/kalium/keys/AuthenticationKey.java
@@ -18,8 +18,8 @@ package org.abstractj.kalium.keys;
 
 import org.abstractj.kalium.encoders.Encoder;
 
-import static org.abstractj.kalium.NaCl.Sodium.HMACSHA512256_BYTES;
-import static org.abstractj.kalium.NaCl.Sodium.HMACSHA512256_KEYBYTES;
+import static org.abstractj.kalium.NaCl.Sodium.CRYPTO_AUTH_HMACSHA512256_BYTES;
+import static org.abstractj.kalium.NaCl.Sodium.CRYPTO_AUTH_HMACSHA512256_KEYBYTES;
 import static org.abstractj.kalium.NaCl.sodium;
 import static org.abstractj.kalium.crypto.Util.checkLength;
 import static org.abstractj.kalium.crypto.Util.isValid;
@@ -32,7 +32,7 @@ public class AuthenticationKey implements Key {
 
     public AuthenticationKey(byte[] key) {
         this.key = key;
-        checkLength(key, HMACSHA512256_KEYBYTES);
+        checkLength(key, CRYPTO_AUTH_HMACSHA512256_KEYBYTES);
     }
 
     public AuthenticationKey(String key, Encoder encoder) {
@@ -40,7 +40,7 @@ public class AuthenticationKey implements Key {
     }
 
     public byte[] sign(byte[] message) {
-        byte[] mac = new byte[HMACSHA512256_BYTES];
+        byte[] mac = new byte[CRYPTO_AUTH_HMACSHA512256_BYTES];
         sodium().crypto_auth_hmacsha512256(mac, message, message.length, key);
         return mac;
     }
@@ -51,7 +51,7 @@ public class AuthenticationKey implements Key {
     }
 
     public boolean verify(byte[] message, byte[] signature) {
-        checkLength(signature, HMACSHA512256_BYTES);
+        checkLength(signature, CRYPTO_AUTH_HMACSHA512256_BYTES);
         return isValid(sodium().crypto_auth_hmacsha512256_verify(signature, message, message.length, key), "signature was forged or corrupted");
     }
 

--- a/src/main/java/org/abstractj/kalium/keys/KeyPair.java
+++ b/src/main/java/org/abstractj/kalium/keys/KeyPair.java
@@ -19,8 +19,8 @@ package org.abstractj.kalium.keys;
 import org.abstractj.kalium.crypto.Point;
 import org.abstractj.kalium.encoders.Encoder;
 
-import static org.abstractj.kalium.NaCl.Sodium.PUBLICKEY_BYTES;
-import static org.abstractj.kalium.NaCl.Sodium.SECRETKEY_BYTES;
+import static org.abstractj.kalium.NaCl.Sodium.CRYPTO_BOX_CURVE25519XSALSA20POLY1305_PUBLICKEYBYTES;
+import static org.abstractj.kalium.NaCl.Sodium.CRYPTO_BOX_CURVE25519XSALSA20POLY1305_SECRETKEYBYTES;
 import static org.abstractj.kalium.NaCl.sodium;
 import static org.abstractj.kalium.crypto.Util.checkLength;
 import static org.abstractj.kalium.crypto.Util.zeros;
@@ -31,14 +31,14 @@ public class KeyPair {
     private final byte[] secretKey;
 
     public KeyPair() {
-        this.secretKey = zeros(SECRETKEY_BYTES);
-        this.publicKey = zeros(PUBLICKEY_BYTES);
+        this.secretKey = zeros(CRYPTO_BOX_CURVE25519XSALSA20POLY1305_SECRETKEYBYTES);
+        this.publicKey = zeros(CRYPTO_BOX_CURVE25519XSALSA20POLY1305_PUBLICKEYBYTES);
         sodium().crypto_box_curve25519xsalsa20poly1305_keypair(publicKey, secretKey);
     }
 
     public KeyPair(byte[] secretKey) {
         this.secretKey = secretKey;
-        checkLength(this.secretKey, SECRETKEY_BYTES);
+        checkLength(this.secretKey, CRYPTO_BOX_CURVE25519XSALSA20POLY1305_SECRETKEYBYTES);
         Point point = new Point();
         this.publicKey = point.mult(secretKey).toBytes();
     }

--- a/src/main/java/org/abstractj/kalium/keys/PrivateKey.java
+++ b/src/main/java/org/abstractj/kalium/keys/PrivateKey.java
@@ -16,7 +16,7 @@
 
 package org.abstractj.kalium.keys;
 
-import static org.abstractj.kalium.NaCl.Sodium.SECRETKEY_BYTES;
+import static org.abstractj.kalium.NaCl.Sodium.CRYPTO_BOX_CURVE25519XSALSA20POLY1305_SECRETKEYBYTES;
 import static org.abstractj.kalium.crypto.Util.checkLength;
 import static org.abstractj.kalium.encoders.Encoder.HEX;
 
@@ -26,12 +26,12 @@ public class PrivateKey implements Key {
 
     public PrivateKey(byte[] secretKey) {
         this.secretKey = secretKey;
-        checkLength(secretKey, SECRETKEY_BYTES);
+        checkLength(secretKey, CRYPTO_BOX_CURVE25519XSALSA20POLY1305_SECRETKEYBYTES);
     }
 
     public PrivateKey(String secretKey) {
         this.secretKey = HEX.decode(secretKey);
-        checkLength(this.secretKey, SECRETKEY_BYTES);
+        checkLength(this.secretKey, CRYPTO_BOX_CURVE25519XSALSA20POLY1305_SECRETKEYBYTES);
     }
 
     @Override

--- a/src/main/java/org/abstractj/kalium/keys/PublicKey.java
+++ b/src/main/java/org/abstractj/kalium/keys/PublicKey.java
@@ -16,7 +16,7 @@
 
 package org.abstractj.kalium.keys;
 
-import static org.abstractj.kalium.NaCl.Sodium.PUBLICKEY_BYTES;
+import static org.abstractj.kalium.NaCl.Sodium.CRYPTO_BOX_CURVE25519XSALSA20POLY1305_PUBLICKEYBYTES;
 import static org.abstractj.kalium.crypto.Util.checkLength;
 import static org.abstractj.kalium.encoders.Encoder.HEX;
 
@@ -26,7 +26,7 @@ public class PublicKey implements Key {
 
     public PublicKey(byte[] publicKey) {
         this.publicKey = publicKey;
-        checkLength(publicKey, PUBLICKEY_BYTES);
+        checkLength(publicKey, CRYPTO_BOX_CURVE25519XSALSA20POLY1305_PUBLICKEYBYTES);
     }
 
     public PublicKey(String publicKey) {

--- a/src/main/java/org/abstractj/kalium/keys/SigningKey.java
+++ b/src/main/java/org/abstractj/kalium/keys/SigningKey.java
@@ -21,9 +21,9 @@ import org.abstractj.kalium.crypto.Random;
 import org.abstractj.kalium.crypto.Util;
 import org.abstractj.kalium.encoders.Encoder;
 
-import static org.abstractj.kalium.NaCl.Sodium.PUBLICKEY_BYTES;
-import static org.abstractj.kalium.NaCl.Sodium.SECRETKEY_BYTES;
-import static org.abstractj.kalium.NaCl.Sodium.SIGNATURE_BYTES;
+import static org.abstractj.kalium.NaCl.Sodium.CRYPTO_BOX_CURVE25519XSALSA20POLY1305_PUBLICKEYBYTES;
+import static org.abstractj.kalium.NaCl.Sodium.CRYPTO_BOX_CURVE25519XSALSA20POLY1305_SECRETKEYBYTES;
+import static org.abstractj.kalium.NaCl.Sodium.CRYPTO_SIGN_ED25519_BYTES;
 import static org.abstractj.kalium.NaCl.sodium;
 import static org.abstractj.kalium.crypto.Util.checkLength;
 import static org.abstractj.kalium.crypto.Util.isValid;
@@ -38,10 +38,10 @@ public class SigningKey {
     private final VerifyKey verifyKey;
 
     public SigningKey(byte[] seed) {
-        checkLength(seed, SECRETKEY_BYTES);
+        checkLength(seed, CRYPTO_BOX_CURVE25519XSALSA20POLY1305_SECRETKEYBYTES);
         this.seed = seed;
-        this.secretKey = zeros(SECRETKEY_BYTES * 2);
-        byte[] publicKey = zeros(PUBLICKEY_BYTES);
+        this.secretKey = zeros(CRYPTO_BOX_CURVE25519XSALSA20POLY1305_SECRETKEYBYTES * 2);
+        byte[] publicKey = zeros(CRYPTO_BOX_CURVE25519XSALSA20POLY1305_PUBLICKEYBYTES);
         isValid(sodium().crypto_sign_ed25519_seed_keypair(publicKey, secretKey, seed),
                 "Failed to generate a key pair");
 
@@ -49,7 +49,7 @@ public class SigningKey {
     }
 
     public SigningKey() {
-        this(new Random().randomBytes(SECRETKEY_BYTES));
+        this(new Random().randomBytes(CRYPTO_BOX_CURVE25519XSALSA20POLY1305_SECRETKEYBYTES));
     }
 
     public SigningKey(String seed, Encoder encoder) {
@@ -61,10 +61,10 @@ public class SigningKey {
     }
 
     public byte[] sign(byte[] message) {
-        byte[] signature = Util.prependZeros(SIGNATURE_BYTES, message);
+        byte[] signature = Util.prependZeros(CRYPTO_SIGN_ED25519_BYTES, message);
         LongLongByReference bufferLen = new LongLongByReference(0);
         sodium().crypto_sign_ed25519(signature, bufferLen, message, message.length, secretKey);
-        signature = slice(signature, 0, SIGNATURE_BYTES);
+        signature = slice(signature, 0, CRYPTO_SIGN_ED25519_BYTES);
         return signature;
     }
 

--- a/src/main/java/org/abstractj/kalium/keys/VerifyKey.java
+++ b/src/main/java/org/abstractj/kalium/keys/VerifyKey.java
@@ -19,8 +19,8 @@ package org.abstractj.kalium.keys;
 import jnr.ffi.byref.LongLongByReference;
 import org.abstractj.kalium.encoders.Encoder;
 
-import static org.abstractj.kalium.NaCl.Sodium.PUBLICKEY_BYTES;
-import static org.abstractj.kalium.NaCl.Sodium.SIGNATURE_BYTES;
+import static org.abstractj.kalium.NaCl.Sodium.CRYPTO_BOX_CURVE25519XSALSA20POLY1305_PUBLICKEYBYTES;
+import static org.abstractj.kalium.NaCl.Sodium.CRYPTO_SIGN_ED25519_BYTES;
 import static org.abstractj.kalium.NaCl.sodium;
 import static org.abstractj.kalium.crypto.Util.checkLength;
 import static org.abstractj.kalium.crypto.Util.isValid;
@@ -33,7 +33,7 @@ public class VerifyKey {
     private byte[] key;
 
     public VerifyKey(byte[] key) {
-        checkLength(key, PUBLICKEY_BYTES);
+        checkLength(key, CRYPTO_BOX_CURVE25519XSALSA20POLY1305_PUBLICKEYBYTES);
         this.key = key;
     }
 
@@ -42,7 +42,7 @@ public class VerifyKey {
     }
 
     public boolean verify(byte[] message, byte[] signature) {
-        checkLength(signature, SIGNATURE_BYTES);
+        checkLength(signature, CRYPTO_SIGN_ED25519_BYTES);
         byte[] sigAndMsg = merge(signature, message);
         byte[] buffer = zeros(sigAndMsg.length);
         LongLongByReference bufferLen = new LongLongByReference(0);

--- a/src/test/java/org/abstractj/kalium/crypto/PasswordTest.java
+++ b/src/test/java/org/abstractj/kalium/crypto/PasswordTest.java
@@ -23,8 +23,8 @@ public class PasswordTest {
         String result = password.hash(PWHASH_MESSAGE.getBytes(),
                 HEX,
                 PWHASH_SALT.getBytes(),
-                NaCl.Sodium.PWHASH_SCRYPTSALSA208SHA256_OPSLIMIT_INTERACTIVE,
-                NaCl.Sodium.PWHASH_SCRYPTSALSA208SHA256_MEMLIMIT_INTERACTIVE);
+                NaCl.Sodium.CRYPTO_PWHASH_SCRYPTSALSA208SHA256_OPSLIMIT_INTERACTIVE,
+                NaCl.Sodium.CRYPTO_PWHASH_SCRYPTSALSA208SHA256_MEMLIMIT_INTERACTIVE);
         assertEquals("Hash is invalid", PWHASH_DIGEST, result);
     }
 
@@ -33,8 +33,8 @@ public class PasswordTest {
         String result = password.hash("".getBytes(),
                 HEX,
                 PWHASH_SALT.getBytes(),
-                NaCl.Sodium.PWHASH_SCRYPTSALSA208SHA256_OPSLIMIT_INTERACTIVE,
-                NaCl.Sodium.PWHASH_SCRYPTSALSA208SHA256_MEMLIMIT_INTERACTIVE);
+                NaCl.Sodium.CRYPTO_PWHASH_SCRYPTSALSA208SHA256_OPSLIMIT_INTERACTIVE,
+                NaCl.Sodium.CRYPTO_PWHASH_SCRYPTSALSA208SHA256_MEMLIMIT_INTERACTIVE);
         assertEquals("Hash is invalid", PWHASH_DIGEST_EMPTY_STRING, result);
     }
 
@@ -44,8 +44,8 @@ public class PasswordTest {
             password.hash("\0".getBytes(),
                     HEX,
                     PWHASH_SALT.getBytes(),
-                    NaCl.Sodium.PWHASH_SCRYPTSALSA208SHA256_OPSLIMIT_INTERACTIVE,
-                    NaCl.Sodium.PWHASH_SCRYPTSALSA208SHA256_MEMLIMIT_INTERACTIVE);
+                    NaCl.Sodium.CRYPTO_PWHASH_SCRYPTSALSA208SHA256_OPSLIMIT_INTERACTIVE,
+                    NaCl.Sodium.CRYPTO_PWHASH_SCRYPTSALSA208SHA256_MEMLIMIT_INTERACTIVE);
         } catch (Exception e) {
             fail("Should not raise any exception on null byte");
         }
@@ -55,8 +55,8 @@ public class PasswordTest {
     public void testPWHashStorage(){
         String result = password.hash(PWHASH_MESSAGE.getBytes(),
                 HEX,
-                NaCl.Sodium.PWHASH_SCRYPTSALSA208SHA256_OPSLIMIT_INTERACTIVE,
-                NaCl.Sodium.PWHASH_SCRYPTSALSA208SHA256_MEMLIMIT_INTERACTIVE);
+                NaCl.Sodium.CRYPTO_PWHASH_SCRYPTSALSA208SHA256_OPSLIMIT_INTERACTIVE,
+                NaCl.Sodium.CRYPTO_PWHASH_SCRYPTSALSA208SHA256_MEMLIMIT_INTERACTIVE);
         byte[] hashed = HEX.decode(result);
 
         // Must return true
@@ -70,27 +70,27 @@ public class PasswordTest {
 
     @Test
     public void testPWHashKeyDerivation() {
-        String result = password.hash(NaCl.Sodium.XSALSA20_POLY1305_SECRETBOX_KEYBYTES,
+        String result = password.hash(NaCl.Sodium.CRYPTO_SECRETBOX_XSALSA20POLY1305_KEYBYTES,
                 PWHASH_MESSAGE.getBytes(),
                 HEX,
                 PWHASH_SALT.getBytes(),
-                NaCl.Sodium.PWHASH_SCRYPTSALSA208SHA256_OPSLIMIT_INTERACTIVE,
-                NaCl.Sodium.PWHASH_SCRYPTSALSA208SHA256_MEMLIMIT_INTERACTIVE);
+                NaCl.Sodium.CRYPTO_PWHASH_SCRYPTSALSA208SHA256_OPSLIMIT_INTERACTIVE,
+                NaCl.Sodium.CRYPTO_PWHASH_SCRYPTSALSA208SHA256_MEMLIMIT_INTERACTIVE);
         byte[] hashed = HEX.decode(result);
 
         // Must receive expected size
-        assertEquals(NaCl.Sodium.XSALSA20_POLY1305_SECRETBOX_KEYBYTES, hashed.length);
+        assertEquals(NaCl.Sodium.CRYPTO_SECRETBOX_XSALSA20POLY1305_KEYBYTES, hashed.length);
     }
 
     @Test
     public void testPWHashKeyDerivationBytes() {
-        byte[] key = password.deriveKey(NaCl.Sodium.XSALSA20_POLY1305_SECRETBOX_KEYBYTES,
+        byte[] key = password.deriveKey(NaCl.Sodium.CRYPTO_SECRETBOX_XSALSA20POLY1305_KEYBYTES,
                 PWHASH_MESSAGE.getBytes(),
                 PWHASH_SALT.getBytes(),
-                NaCl.Sodium.PWHASH_SCRYPTSALSA208SHA256_OPSLIMIT_INTERACTIVE,
-                NaCl.Sodium.PWHASH_SCRYPTSALSA208SHA256_MEMLIMIT_INTERACTIVE);
+                NaCl.Sodium.CRYPTO_PWHASH_SCRYPTSALSA208SHA256_OPSLIMIT_INTERACTIVE,
+                NaCl.Sodium.CRYPTO_PWHASH_SCRYPTSALSA208SHA256_MEMLIMIT_INTERACTIVE);
 
         // Must receive expected size
-        assertEquals(NaCl.Sodium.XSALSA20_POLY1305_SECRETBOX_KEYBYTES, key.length);
+        assertEquals(NaCl.Sodium.CRYPTO_SECRETBOX_XSALSA20POLY1305_KEYBYTES, key.length);
     }
 }

--- a/src/test/java/org/abstractj/kalium/crypto/SealedBoxTest.java
+++ b/src/test/java/org/abstractj/kalium/crypto/SealedBoxTest.java
@@ -4,8 +4,8 @@ import org.junit.Test;
 
 import java.security.SecureRandom;
 
-import static org.abstractj.kalium.NaCl.Sodium.PUBLICKEY_BYTES;
-import static org.abstractj.kalium.NaCl.Sodium.SECRETKEY_BYTES;
+import static org.abstractj.kalium.NaCl.Sodium.CRYPTO_BOX_CURVE25519XSALSA20POLY1305_PUBLICKEYBYTES;
+import static org.abstractj.kalium.NaCl.Sodium.CRYPTO_BOX_CURVE25519XSALSA20POLY1305_SECRETKEYBYTES;
 import static org.abstractj.kalium.NaCl.sodium;
 import static org.junit.Assert.assertArrayEquals;
 
@@ -14,8 +14,8 @@ public class SealedBoxTest {
     @Test
     public void testEncryptDecrypt() throws Exception {
         SecureRandom r = new SecureRandom();
-        byte[] pk = new byte[PUBLICKEY_BYTES];
-        byte[] sk = new byte[SECRETKEY_BYTES];
+        byte[] pk = new byte[CRYPTO_BOX_CURVE25519XSALSA20POLY1305_PUBLICKEYBYTES];
+        byte[] sk = new byte[CRYPTO_BOX_CURVE25519XSALSA20POLY1305_SECRETKEYBYTES];
         byte[] m = new byte[r.nextInt(1000)];
 
         sodium().crypto_box_curve25519xsalsa20poly1305_keypair(pk, sk);
@@ -32,8 +32,8 @@ public class SealedBoxTest {
     @Test(expected = RuntimeException.class)
     public void testDecryptFailsFlippedKeys() throws Exception {
         SecureRandom r = new SecureRandom();
-        byte[] pk = new byte[PUBLICKEY_BYTES];
-        byte[] sk = new byte[SECRETKEY_BYTES];
+        byte[] pk = new byte[CRYPTO_BOX_CURVE25519XSALSA20POLY1305_PUBLICKEYBYTES];
+        byte[] sk = new byte[CRYPTO_BOX_CURVE25519XSALSA20POLY1305_SECRETKEYBYTES];
         byte[] m = new byte[r.nextInt(1000)];
 
         sodium().crypto_box_curve25519xsalsa20poly1305_keypair(pk, sk);

--- a/src/test/java/org/abstractj/kalium/keys/AuthenticationKeyTest.java
+++ b/src/test/java/org/abstractj/kalium/keys/AuthenticationKeyTest.java
@@ -20,9 +20,9 @@ import org.junit.Test;
 
 import java.util.Arrays;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertEquals;
-import static org.abstractj.kalium.NaCl.Sodium.HMACSHA512256_KEYBYTES;
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertTrue;
+import static org.abstractj.kalium.NaCl.Sodium.CRYPTO_AUTH_HMACSHA512256_KEYBYTES;
 import static org.abstractj.kalium.encoders.Encoder.HEX;
 import static org.abstractj.kalium.fixture.TestVectors.AUTH_HMAC_SHA512256;
 import static org.abstractj.kalium.fixture.TestVectors.AUTH_KEY;
@@ -66,7 +66,7 @@ public class AuthenticationKeyTest {
 
     @Test(expected = RuntimeException.class)
     public void testRejectLongKey() throws Exception {
-        byte[] key = new byte[HMACSHA512256_KEYBYTES + 1];
+        byte[] key = new byte[CRYPTO_AUTH_HMACSHA512256_KEYBYTES + 1];
         new AuthenticationKey(key);
         fail("Should reject long keys");
     }


### PR DESCRIPTION
Note, this pull-request is currently based from #57. These changes are broken out from #48.

It would be useful to keep the constraint names consistent with libsodium to avoid confusion for those with libsodium experience and to avoid issues like BLAKE2B_OUTBYTES differing from CRYPTO_GENERICHASH_BLAKE2B_BYTES.

Note that this pull request partly reverts 733d3e6 in favor of deprecation. I'm happy to flip it back if you think that is better. It updates crypto.Hash to use '32' byte outlen, but leaves 'BLAKE2B_OUTBYTES' as '64'. 

Commits in addition to changes in #57 included in this PR.
* 87617a4 Rename constants to be consistent with libsodium.
* 66a1a0b Add back original Kalium constants with '@Deprecated' warnings.