### PR TITLE
Proper name for Sodium dynamic library on Win32 (fixes #65)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,4 @@ Add as a Maven dependency at your project:
 kalium is a work in progress, feedback, bug reports and patches are always welcome.
 
 [![Build Status](https://travis-ci.org/abstractj/kalium.png?branch=master)](https://travis-ci.org/abstractj/kalium)
-
-
-
+[![Build status](https://ci.appveyor.com/api/projects/status/github/abstractj/kalium?branch=master&svg=true)](https://ci.appveyor.com/project/abstractj/kalium/branch/master)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,22 @@
+version: '{build}'
+os: Windows Server 2012
+install:
+  - cmd: SET JAVA_HOME=C:\Program Files (x86)\Java\jdk1.8.0
+  - cmd: SET LIBSODIUM_VERSION=1.0.3
+  - ps: |
+      Add-Type -AssemblyName System.IO.Compression.FileSystem
+      if (!(Test-Path -Path "C:\libsodium" )) {
+        (New-Object System.Net.WebClient).DownloadFile(
+          "https://github.com/jedisct1/libsodium/archive/$env:LIBSODIUM_VERSION.zip",
+          'C:\libsodium.zip'
+        )
+        [System.IO.Compression.ZipFile]::ExtractToDirectory("C:\libsodium.zip", "C:\")
+        Rename-Item C:\libsodium-$env:LIBSODIUM_VERSION C:\libsodium
+      }
+  - cmd: msbuild C:\libsodium\libsodium.vcxproj /property:Configuration=ReleaseDLL /verbosity:minimal /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+  - cmd: SET PATH=C:\libsodium\Build\ReleaseDLL\Win32;%PATH%
+build_script:
+  - mvn clean install -q --batch-mode -DargLine=-Dfile.encoding=UTF-8
+cache:
+  - C:\libsodium
+  - C:\Users\appveyor\.m2

--- a/src/main/java/org/abstractj/kalium/NaCl.java
+++ b/src/main/java/org/abstractj/kalium/NaCl.java
@@ -17,6 +17,7 @@
 package org.abstractj.kalium;
 
 import jnr.ffi.LibraryLoader;
+import jnr.ffi.Platform;
 import jnr.ffi.annotations.In;
 import jnr.ffi.annotations.Out;
 import jnr.ffi.byref.LongLongByReference;
@@ -30,7 +31,16 @@ public class NaCl {
         return sodium;
     }
 
-    private static final String LIBRARY_NAME = "sodium";
+    private static final String LIBRARY_NAME = libraryName();
+
+    private static String libraryName() {
+        switch (Platform.getNativePlatform().getOS()) {
+            case WINDOWS:
+                return "libsodium";
+            default:
+                return "sodium";
+        }
+    }
 
     private static final class SingletonHolder {
         public static final Sodium SODIUM_INSTANCE =


### PR DESCRIPTION
Sodium build for Win32 produces dynamic library with 'lib' prefix, so that FFI layer could find it we have to name it explicitly "libsodium", rather that simply "sodium". It is because FFI does not try to automatically prepend 'lib' prefix when searching library in Win32, like it does in Linux. It fixes #65.

I also added configuration for [AppVeyor CI](https://www.appveyor.com) to run tests on Win32 so that we can check compatibility with that platform.

Tests show that dynamic library is loaded correctly, but unexpectedly.. a [few HashTest's is failed](https://ci.appveyor.com/project/nartamonov/kalium/build/22), because Blake2 hashing gives wrong results. I think it is bug in FFI layer. All other tests are OK. Any ideas? Should I open new issue?