### PR TITLE
Use detached variants of sign/verify functions

### DIFF
--- a/src/main/java/org/abstractj/kalium/NaCl.java
+++ b/src/main/java/org/abstractj/kalium/NaCl.java
@@ -251,6 +251,14 @@ public class NaCl {
                 @In byte[] sigAndMsg, @In @u_int64_t int length,
                 @In byte[] key);
 
+        int crypto_sign_ed25519_detached(@Out byte[] sig, @Out LongLongByReference sigLen,
+                @In byte[] message, @In @u_int64_t int length,
+                @In byte[] secretKey);
+
+        int crypto_sign_ed25519_verify_detached(@In byte[] sig,
+                @In byte[] message, @In @u_int64_t int length,
+                @In byte[] key);
+
         // ---------------------------------------------------------------------
         // Public-key cryptography: Sealed boxes
 

--- a/src/main/java/org/abstractj/kalium/keys/SigningKey.java
+++ b/src/main/java/org/abstractj/kalium/keys/SigningKey.java
@@ -61,10 +61,9 @@ public class SigningKey {
     }
 
     public byte[] sign(byte[] message) {
-        byte[] signature = Util.prependZeros(CRYPTO_SIGN_ED25519_BYTES, message);
+        byte[] signature = new byte[CRYPTO_SIGN_ED25519_BYTES];
         LongLongByReference bufferLen = new LongLongByReference(0);
-        sodium().crypto_sign_ed25519(signature, bufferLen, message, message.length, secretKey);
-        signature = slice(signature, 0, CRYPTO_SIGN_ED25519_BYTES);
+        sodium().crypto_sign_ed25519_detached(signature, bufferLen, message, message.length, secretKey);
         return signature;
     }
 

--- a/src/main/java/org/abstractj/kalium/keys/VerifyKey.java
+++ b/src/main/java/org/abstractj/kalium/keys/VerifyKey.java
@@ -16,7 +16,6 @@
 
 package org.abstractj.kalium.keys;
 
-import jnr.ffi.byref.LongLongByReference;
 import org.abstractj.kalium.encoders.Encoder;
 
 import static org.abstractj.kalium.NaCl.Sodium.CRYPTO_BOX_CURVE25519XSALSA20POLY1305_PUBLICKEYBYTES;
@@ -24,8 +23,6 @@ import static org.abstractj.kalium.NaCl.Sodium.CRYPTO_SIGN_ED25519_BYTES;
 import static org.abstractj.kalium.NaCl.sodium;
 import static org.abstractj.kalium.crypto.Util.checkLength;
 import static org.abstractj.kalium.crypto.Util.isValid;
-import static org.abstractj.kalium.crypto.Util.merge;
-import static org.abstractj.kalium.crypto.Util.zeros;
 import static org.abstractj.kalium.encoders.Encoder.HEX;
 
 public class VerifyKey {
@@ -43,11 +40,7 @@ public class VerifyKey {
 
     public boolean verify(byte[] message, byte[] signature) {
         checkLength(signature, CRYPTO_SIGN_ED25519_BYTES);
-        byte[] sigAndMsg = merge(signature, message);
-        byte[] buffer = zeros(sigAndMsg.length);
-        LongLongByReference bufferLen = new LongLongByReference(0);
-
-        return isValid(sodium().crypto_sign_ed25519_open(buffer, bufferLen, sigAndMsg, sigAndMsg.length, key), "signature was forged or corrupted");
+        return isValid(sodium().crypto_sign_ed25519_verify_detached(signature, message, message.length, key), "signature was forged or corrupted");
     }
 
     public boolean verify(String message, String signature, Encoder encoder) {


### PR DESCRIPTION
`crypto_sign_ed25519_detached` and `crypto_sign_ed25519_verify_detached`
are used in `SigningKey` and `VerifyKey` to avoid extra allocations
(`Util.merge`/`Util.prependZeros` calls).

Compatible with `libsodium` >= 1.0.3.

Fixes #72.