### PR TITLE
Implement short-input hashing

### DIFF
--- a/src/main/java/org/abstractj/kalium/NaCl.java
+++ b/src/main/java/org/abstractj/kalium/NaCl.java
@@ -302,7 +302,11 @@ public class NaCl {
         // ---------------------------------------------------------------------
         // Hashing: Short-input hashing
 
-        // TODO
+        int CRYPTO_SHORTHASH_SIPHASH24_BYTES = 8;
+
+        int CRYPTO_SHORTHASH_SIPHASH24_KEYBYTES = 16;
+
+        int crypto_shorthash_siphash24(@Out byte[] out, @In byte[] in, @u_int64_t int inLen, @In byte[] key);
 
         // ---------------------------------------------------------------------
         // Password hashing

--- a/src/main/java/org/abstractj/kalium/crypto/ShortHash.java
+++ b/src/main/java/org/abstractj/kalium/crypto/ShortHash.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2017 Bruno Oliveira, and individual contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.abstractj.kalium.crypto;
+
+import static org.abstractj.kalium.NaCl.sodium;
+import static org.abstractj.kalium.NaCl.Sodium.CRYPTO_SHORTHASH_SIPHASH24_BYTES;
+import static org.abstractj.kalium.NaCl.Sodium.CRYPTO_SHORTHASH_SIPHASH24_KEYBYTES;
+import static org.abstractj.kalium.crypto.Util.checkLength;
+import static org.abstractj.kalium.crypto.Util.isValid;
+
+public class ShortHash {
+
+    public byte[] siphash24(byte[] message, byte[] key) {
+        byte[] buffer = new byte[CRYPTO_SHORTHASH_SIPHASH24_BYTES];
+        checkLength(key, CRYPTO_SHORTHASH_SIPHASH24_KEYBYTES);
+        isValid(sodium().crypto_shorthash_siphash24(buffer, message, message.length, key), "Hashing failed");
+        return buffer;
+    }
+
+}

--- a/src/test/java/org/abstractj/kalium/crypto/ShortHashTest.java
+++ b/src/test/java/org/abstractj/kalium/crypto/ShortHashTest.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2017 Bruno Oliveira, and individual contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.abstractj.kalium.crypto;
+
+import org.junit.Test;
+
+import static org.abstractj.kalium.encoders.Encoder.HEX;
+import static org.abstractj.kalium.fixture.TestVectors.SIPHASH24_KEY;
+import static org.abstractj.kalium.fixture.TestVectors.SIPHASH24_MESSAGE;
+import static org.abstractj.kalium.fixture.TestVectors.SIPHASH24_DIGEST;
+import static org.abstractj.kalium.fixture.TestVectors.SIPHASH24_DIGEST_EMPTY_STRING;
+
+import static org.junit.Assert.assertEquals;
+
+public class ShortHashTest {
+
+    private final ShortHash hash = new ShortHash();
+
+    @Test
+    public void testSiphash24() throws Exception {
+        byte[] message = HEX.decode(SIPHASH24_MESSAGE);
+        byte[] key = HEX.decode(SIPHASH24_KEY);
+        String result = HEX.encode(hash.siphash24(message, key));
+        assertEquals("Hash is invalid", SIPHASH24_DIGEST, result);
+    }
+
+    @Test
+    public void testSiphash24EmptyString() throws Exception {
+        byte[] key = HEX.decode(SIPHASH24_KEY);
+        String result = HEX.encode(hash.siphash24(new byte[0], key));
+        assertEquals("Hash is invalid", SIPHASH24_DIGEST_EMPTY_STRING, result);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testSiphash24InvalidKey() throws Exception {
+        byte[] message = HEX.decode(SIPHASH24_MESSAGE);
+        byte[] invalidKey = new byte[1];
+        hash.siphash24(message, invalidKey);
+    }
+}

--- a/src/test/java/org/abstractj/kalium/fixture/TestVectors.java
+++ b/src/test/java/org/abstractj/kalium/fixture/TestVectors.java
@@ -60,6 +60,14 @@ public class TestVectors {
     public static final String Blake2_PERSONAL = "fedcba9876543210";
     public static final String Blake2_DIGEST_WITH_SALT_PERSONAL = "108e81d0c7b0487de45c54554ea35b427f886b098d792497c6a803bbac7a5f7c";
 
+    /**
+     * SipHash-2-4 test vectors
+     */
+
+    public static final String SIPHASH24_KEY = "000102030405060708090a0b0c0d0e0f";
+    public static final String SIPHASH24_MESSAGE = "000102030405060708090a0b0c0d0e";
+    public static final String SIPHASH24_DIGEST = "e545be4961ca29a1";
+    public static final String SIPHASH24_DIGEST_EMPTY_STRING = "310e0edd47db6f72";
 
     /**
      * pwhash test vectors


### PR DESCRIPTION
This patch adds support for [short-input hashing](https://download.libsodium.org/doc/hashing/short-input_hashing.html) based on SipHash-2-4.