### PR TITLE
Split out the shared key functionality from Box.

### DIFF
--- a/src/main/java/org/abstractj/kalium/keys/SharedKey.java
+++ b/src/main/java/org/abstractj/kalium/keys/SharedKey.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright 2013,2017 Bruno Oliveira, and individual contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.abstractj.kalium.keys;
+
+import org.abstractj.kalium.encoders.Encoder;
+import static org.abstractj.kalium.NaCl.Sodium.CRYPTO_BOX_CURVE25519XSALSA20POLY1305_BEFORENMBYTES;
+import static org.abstractj.kalium.NaCl.Sodium.CRYPTO_BOX_CURVE25519XSALSA20POLY1305_PUBLICKEYBYTES;
+import static org.abstractj.kalium.NaCl.Sodium.CRYPTO_BOX_CURVE25519XSALSA20POLY1305_SECRETKEYBYTES;
+import static org.abstractj.kalium.NaCl.sodium;
+import static org.abstractj.kalium.crypto.Util.checkLength;
+import static org.abstractj.kalium.crypto.Util.isValid;
+import static org.abstractj.kalium.encoders.Encoder.HEX;
+
+public class SharedKey implements Key {
+
+    private final byte[] sharedKey;
+
+    public SharedKey(byte[] sharedKey) {
+        checkLength(sharedKey, CRYPTO_BOX_CURVE25519XSALSA20POLY1305_BEFORENMBYTES);
+        this.sharedKey = sharedKey;
+    }
+
+    public SharedKey(String sharedKey, Encoder encoder) {
+        this(encoder.decode(sharedKey));
+    }
+
+    public SharedKey(String sharedKey) {
+        this(sharedKey, HEX);
+    }
+
+    public SharedKey(byte[] publicKey, byte[] privateKey) {
+        checkLength(publicKey, CRYPTO_BOX_CURVE25519XSALSA20POLY1305_PUBLICKEYBYTES);
+        checkLength(privateKey, CRYPTO_BOX_CURVE25519XSALSA20POLY1305_SECRETKEYBYTES);
+
+        sharedKey = new byte[CRYPTO_BOX_CURVE25519XSALSA20POLY1305_BEFORENMBYTES];
+        isValid(sodium().crypto_box_curve25519xsalsa20poly1305_beforenm(
+                sharedKey, publicKey, privateKey), "Key agreement failed");
+    }
+
+    public SharedKey(PublicKey publicKey, PrivateKey privateKey) {
+        this(publicKey.toBytes(), privateKey.toBytes());
+    }
+
+    public SharedKey(String publicKey, String privateKey, Encoder encoder) {
+        this(encoder.decode(publicKey), encoder.decode(privateKey));
+    }
+
+    public SharedKey(String publicKey, String privateKey) {
+        this(publicKey, privateKey, HEX);
+    }
+
+    @Override
+    public byte[] toBytes() {
+        return sharedKey;
+    }
+
+    @Override
+    public String toString() {
+        return HEX.encode(sharedKey);
+    }
+}

--- a/src/test/java/org/abstractj/kalium/fixture/TestVectors.java
+++ b/src/test/java/org/abstractj/kalium/fixture/TestVectors.java
@@ -82,6 +82,8 @@ public class TestVectors {
     public static final String ALICE_PUBLIC_KEY = "8520f0098930a754748b7ddcb43ef75a0dbf3a0d26381af4eba4a98eaa9b4e6a";
     public static final String ALICE_MULT_BOB = "4a5d9d5ba4ce2de1728e3bf480350f25e07e21c947d19e3376f09b3c1e161742";
 
+    public static final String ALICE_BOB_SHARED_KEY = "1b27556473e985d462cd51197a9a46c76009549eac6474f206c4ee0844f68389";
+
     public static final String BOX_NONCE = "69696ee955b62b73cd62bda875fc73d68219e0036b7a0b37";
     public static final String BOX_MESSAGE = "be075fc53c81f2d5cf141316ebeb0c7b5228c52a4c62cbd44b66849b64244ffc" +
             "e5ecbaaf33bd751a1ac728d45e6c61296cdc3c01233561f41db66cce314adb31" +

--- a/src/test/java/org/abstractj/kalium/keys/SharedKeyTest.java
+++ b/src/test/java/org/abstractj/kalium/keys/SharedKeyTest.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2013,2017 Bruno Oliveira, and individual contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.abstractj.kalium.keys;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+
+import static org.abstractj.kalium.fixture.TestVectors.ALICE_PRIVATE_KEY;
+import static org.abstractj.kalium.fixture.TestVectors.ALICE_PUBLIC_KEY;
+import static org.abstractj.kalium.fixture.TestVectors.BOB_PUBLIC_KEY;
+import static org.abstractj.kalium.fixture.TestVectors.BOB_PRIVATE_KEY;
+import static org.abstractj.kalium.fixture.TestVectors.ALICE_BOB_SHARED_KEY;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class SharedKeyTest {
+
+    @Test
+    public void testAliceToBob() throws Exception {
+        SharedKey sharedKey = new SharedKey(ALICE_PUBLIC_KEY, BOB_PRIVATE_KEY);
+        assertEquals("Should return the correct shared secret", ALICE_BOB_SHARED_KEY, sharedKey.toString());
+    }
+
+    @Test
+    public void testBobToAlice() throws Exception {
+        SharedKey sharedKey = new SharedKey(BOB_PUBLIC_KEY, ALICE_PRIVATE_KEY);
+        assertEquals("Should return the correct shared secret", ALICE_BOB_SHARED_KEY, sharedKey.toString());
+    }
+}


### PR DESCRIPTION
Useful if you need key agreement for something else than encrypting messages.