### PR TITLE
Derive Public Keys from existing Private Keys

### DIFF
--- a/src/main/java/org/abstractj/kalium/NaCl.java
+++ b/src/main/java/org/abstractj/kalium/NaCl.java
@@ -200,6 +200,9 @@ public class NaCl {
 
         int CRYPTO_BOX_CURVE25519XSALSA20POLY1305_BEFORENMBYTES = 32;
 
+        int crypto_scalarmult_base(
+            @Out byte[] publicKey, @In byte[] secretKey);
+
         int crypto_box_curve25519xsalsa20poly1305_keypair(
                 @Out byte[] publicKey, @Out byte[] secretKey);
 


### PR DESCRIPTION
Added functionality for `crypto_scalarmult_base` for deriving public keys from existing private keys.

See https://download.libsodium.org/doc/public-key_cryptography/authenticated_encryption.html for more info