### PR TITLE
Specify Encoding for Version String (#87)

### DIFF
--- a/src/main/java/org/abstractj/kalium/NaCl.java
+++ b/src/main/java/org/abstractj/kalium/NaCl.java
@@ -19,6 +19,7 @@ package org.abstractj.kalium;
 import jnr.ffi.LibraryLoader;
 import jnr.ffi.Platform;
 import jnr.ffi.annotations.In;
+import jnr.ffi.annotations.Encoding;
 import jnr.ffi.annotations.Out;
 import jnr.ffi.byref.LongLongByReference;
 import jnr.ffi.types.u_int64_t;
@@ -85,6 +86,7 @@ public class NaCl {
          */
         int sodium_init();
 
+        @Encoding("US-ASCII")
         String sodium_version_string();
 
         // ---------------------------------------------------------------------

--- a/src/test/java/org/abstractj/kalium/crypto/UtilTest.java
+++ b/src/test/java/org/abstractj/kalium/crypto/UtilTest.java
@@ -16,8 +16,11 @@
 
 package org.abstractj.kalium.crypto;
 
+import org.abstractj.kalium.NaCl;
 import org.junit.Assert;
 import org.junit.Test;
+
+import java.util.regex.Pattern;
 
 public class UtilTest {
     @Test
@@ -30,5 +33,11 @@ public class UtilTest {
     @Test(expected = RuntimeException.class)
     public void testDataNull() {
         Util.checkLength(null, 3);
+    }
+
+    @Test
+    public void testSodiumVersion() {
+        Assert.assertTrue(NaCl.sodium().sodium_version_string() + " did not match expected pattern.",
+            Pattern.matches("^\\d+\\.\\d+\\.\\d+$",NaCl.sodium().sodium_version_string()));
     }
 }


### PR DESCRIPTION
Added an annotation to the sodium_version_string() method so it
is always read as an ASCII string. Avoids some issues on Windows
with reading multi-byte strings by default.

Added a test to make sure version string matches the expected
pattern.